### PR TITLE
partial func, not support passing param by name(command)

### DIFF
--- a/supervisor_alert.py
+++ b/supervisor_alert.py
@@ -48,7 +48,7 @@ def main():
     if args.telegram:
         alert = telegram
     elif args.command:
-        alert = partial(send, command=shlex.split(args.command))
+        alert = partial(send, shlex.split(args.command))
     else:
         raise Exception("No command specified.")
 


### PR DESCRIPTION
unfortunately, partial func doesn't support passing param by name.
so `command=` exp is not good to using `-c` option
even python 2.5.14